### PR TITLE
Check for empty value

### DIFF
--- a/WireWordTools.module
+++ b/WireWordTools.module
@@ -250,7 +250,7 @@ class WireWordTools extends WireData implements Module, ConfigurableModule {
 		$fs = $this->wire()->modules->get('InputfieldFieldset');
 		$fs->attr('name', '_test_words');
 		$fs->label = 'Test word functions';
-		if(count($results)) $fs->description = implode("\n", $results);
+		if(!empty($results) && count($results)) $fs->description = implode("\n", $results);
 		$inputfields->add($fs);
 		
 		/** @var InputfieldSelect $f */


### PR DESCRIPTION
Fixes TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given

Running:
PHP 8.0.18
MySQL 8.0.28
ProcessWire 3.0.200